### PR TITLE
Options dialog for plugin, and bug fixes for multiple tabs and plugin unloading.

### DIFF
--- a/autotab.py
+++ b/autotab.py
@@ -192,16 +192,18 @@ class AutoTab(GObject.Object, Gedit.WindowActivatable):
     self.update_tabs(self.tabs_width, self.spaces_instead_of_tabs)
 
   # Update the values and set a new statusbar message
-  def update_tabs(self, size, space):
-    view = self.window.get_active_view()
+  def update_tabs(self, size, space, view=None):
+    if view is None:
+      view = self.window.get_active_view()
     if view:
       view.set_tab_width(size)
       view.set_insert_spaces_instead_of_tabs(space)
-      self.update_status()
+      self.update_status(view)
 
   # Statusbar message
-  def update_status(self):
-    view = self.window.get_active_view()
+  def update_status(self, view=None):
+    if view is None:
+      view = self.window.get_active_view()
     if view:
       space = view.get_insert_spaces_instead_of_tabs()
       size = view.get_tab_width()
@@ -256,7 +258,7 @@ class AutoTab(GObject.Object, Gedit.WindowActivatable):
 
     # Special case for makefiles, so the plugin uses tabs even for the empty file:
     if doc.get_mime_type() == "text/x-makefile" or doc.get_short_name_for_display() == "Makefile":
-      self.update_tabs(self.tabs_width, False)
+      self.update_tabs(self.tabs_width, False, view)
       return
 
     start, end = doc.get_bounds()
@@ -309,9 +311,9 @@ class AutoTab(GObject.Object, Gedit.WindowActivatable):
       # can't guess at size, so using default
       if seen_tabs or seen_spaces:
         if seen_tabs > seen_spaces:
-          self.update_tabs(self.tabs_width, False)
+          self.update_tabs(self.tabs_width, False, view)
         else:
-          self.update_tabs(self.tabs_width, True)
+          self.update_tabs(self.tabs_width, True, view)
       return
 
     winner = None
@@ -322,6 +324,6 @@ class AutoTab(GObject.Object, Gedit.WindowActivatable):
         winner = key
 
     if winner == 'tabs':
-      self.update_tabs(self.tabs_width, False)
+      self.update_tabs(self.tabs_width, False, view)
     else:
-      self.update_tabs(winner, True)
+      self.update_tabs(winner, True, view)

--- a/autotab.py
+++ b/autotab.py
@@ -76,16 +76,16 @@ class AutoTab(GObject.Object, Gedit.WindowActivatable):
     loaded_id = doc.connect_after("loaded", self.auto_tab, view)
     saved_id  = doc.connect_after("saved", self.auto_tab, view)
     pasted_id = view.connect("paste-clipboard", self.on_paste)
-    #doc.AutoTabPluginHandlerIds = (loaded_id, saved_id, pasted_id)
-    doc.AutoTabPluginHandlerIds = (loaded_id, saved_id)
+    doc.AutoTabPluginHandlerIds = (loaded_id, saved_id, pasted_id)
+    #doc.AutoTabPluginHandlerIds = (loaded_id, saved_id)
 
   def disconnect_handlers(self, view):
     doc = view.get_buffer()
-    #loaded_id, saved_id, pasted_id = doc.AutoTabPluginHandlerIds
-    loaded_id, saved_id = doc.AutoTabPluginHandlerIds
+    loaded_id, saved_id, pasted_id = doc.AutoTabPluginHandlerIds
+    #loaded_id, saved_id = doc.AutoTabPluginHandlerIds
     doc.disconnect(loaded_id)
     doc.disconnect(saved_id)
-    #view.disconnect(pasted_id)
+    view.disconnect(pasted_id)
     doc.AutoTabPluginHandlerIds = None
 
   def on_clipboard_text(self, clipboard, text, view):


### PR DESCRIPTION
Each in a separate commit... the big change is the options dialog. Integrating with GSettings was difficult while maintaining the ability to just drop the plugin in the `~/.local/share/gedit/plugins` directory, so i wrote a simple config file saver / loader to save the options. It saves config as `~/.config/gedit/autotab`.

The options are currently:
* Guess Document Indentation - turns the main functionality on or off
* Convert Clipboard Text - turns the clipboard paste functionality on or off

In addition to this there were a couple bugfixes.

Bugfix one: The clipboard paste handler wasn't being properly disconnected when deactivating the plugin.

Bugfix Two: When multiple tabs were open the tab settings were being applied always to the active tab, in stead of the one actually being parsed. This resulted in various problems when the plugin was activated with multiple tabs open.